### PR TITLE
Partial fix of search index

### DIFF
--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -127,7 +127,7 @@ class IndexedSearch
         $blarray = [];
         $db = Loader::db();
         $r = $db->Execute(
-            'select bID, arHandle from CollectionVersionBlocks where cID = ? and cvID = ?',
+            'SELECT `bID`, `arHandle` FROM `CollectionVersionBlocks` WHERE `cID` = ? AND `cvID` = ? ORDER BY `arHandle` ASC, `cbDisplayOrder` ASC',
             [$c->getCollectionID(), $c->getVersionID()]
         );
         $th = Loader::helper('text');


### PR DESCRIPTION
Partial fix of https://github.com/concrete5/concrete5/issues/9358#issue-802102428.
This change ensures that blocks within areas are indexed in their on-page order, but does not resolve the issue for area sequence or layouts or other accumulations of blocks within areas. Hence it is an improvement, but not a complete solution to a correctly sequenced search index.
